### PR TITLE
Set up manually triggered deploy action to GitHub Packages

### DIFF
--- a/.github/workflows/jdt-aspectj-deploy.yml
+++ b/.github/workflows/jdt-aspectj-deploy.yml
@@ -1,0 +1,26 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Deploy AspectJ JDT Core
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 14
+        uses: actions/setup-java@v2
+        with:
+          java-version: '14'
+          distribution: 'adopt'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Publish to GitHub Packages
+        run: mvn -B deploy -s $GITHUB_WORKSPACE/settings.xml --file org.eclipse.jdt.core/pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
Unfortunately, I cannot just add GitHub Actions in a branch, if I want to be able to manually start a workflow from the GitHub website later. GH only recognises a workflow in a branch if it is also defined in the main/master branch. This is why we need this commit on main. In the future, we have the following options:
  * Never update main in this repo, just merge in Eclipse master locally and push to aj_19 or whatever is the current development branch.
  * Regularly merge Eclipse master into main here, then push.
  * Regularly rebase this additional commit on Eclipse master locally, then force-push. This would avoid merge commits.