### PR TITLE
No tabs in compiler messages + build-time verification

### DIFF
--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/messages.properties
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/messages.properties
@@ -9,19 +9,19 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
-#     IBM Corporation - initial API and implementation
-#		Benjamin Muskalla - Contribution for bug 239066
-#		Stephan Herrmann - Contributions for
-#								bug 236385 - [compiler] Warn for potential programming problem if an object is created but not used
-#								bug 295551 - Add option to automatically promote all warnings to errors
-#								bug 359721 - [options] add command line option for new warning token "resource"
-#								bug 365208 - [compiler][batch] command line options for annotation based null analysis
-#								bug 374605 - Unreasonable warning for enum-based switch statements
-#								bug 388281 - [compiler][null] inheritance of null annotations as an option
-#								bug 440687 - [compiler][batch][null] improve command line option for external annotations
-#								Bug 408815 - [batch][null] Add CLI option for COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS
-#		Alan Moraes <alan@kelon.org> - Contribution for bug 383644
-#		Jesper S Moller - Contribution for bug 407297 - [1.8][compiler] Control generation of parameter names by option
+#   IBM Corporation - initial API and implementation
+#   Benjamin Muskalla - Contribution for bug 239066
+#   Stephan Herrmann - Contributions for
+#     bug 236385 - [compiler] Warn for potential programming problem if an object is created but not used
+#     bug 295551 - Add option to automatically promote all warnings to errors
+#     bug 359721 - [options] add command line option for new warning token "resource"
+#     bug 365208 - [compiler][batch] command line options for annotation based null analysis
+#     bug 374605 - Unreasonable warning for enum-based switch statements
+#     bug 388281 - [compiler][null] inheritance of null annotations as an option
+#     bug 440687 - [compiler][batch][null] improve command line option for external annotations
+#     Bug 408815 - [batch][null] Add CLI option for COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS
+#   Alan Moraes <alan@kelon.org> - Contribution for bug 383644
+#   Jesper S Moller - Contribution for bug 407297 - [1.8][compiler] Control generation of parameter names by option
 ###############################################################################
 ### JavaBatchCompiler messages.
 

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -419,27 +419,7 @@
 
     <plugins>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-versions</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <!-- Because org.eclipse.jdt.compiler.apt/lib/javax15api.jar has Java 14 byte code version -->
-                  <version>14</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
+      <!-- Build Helper must run *before* Enforcer, because the latter uses a property defined by the former -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -467,6 +447,67 @@
                 <!-- Add compiler APT support -->
                 <source>${project.basedir}/../org.eclipse.jdt.compiler.apt/src</source>
               </sources>
+            </configuration>
+          </execution>
+          <!--
+            Replace '\' Windows file separators by '/' in order to expand the new property 'compiler-message-properties'
+            into a string literal in Maven Enforcer rule 'evaluateBeanshell' further below.
+          -->
+          <execution>
+            <id>compiler-message-properties</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>compiler-message-properties</name>
+              <value>${project.basedir}/batch/org/eclipse/jdt/internal/compiler/batch/messages.properties</value>
+              <regex>\\</regex>
+              <replacement>/</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-rules</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <!-- Because org.eclipse.jdt.compiler.apt/lib/javax15api.jar has Java 14 byte code version -->
+                  <version>14</version>
+                </requireJavaVersion>
+                <evaluateBeanshell>
+                  <message>
+                    Compiler message resource file ${compiler-message-properties} must not contain tab characters, please use spaces instead!
+                  </message>
+                  <condition><![CDATA[
+                    FileReader fileReader = new FileReader("${compiler-message-properties}");
+                    BufferedReader bufferReader = new BufferedReader(fileReader);
+                    boolean containsTab = false;
+                    String line;
+                    while((line = bufferReader.readLine()) != null) {
+                      if (line.contains("\t")) {
+                        if (!containsTab) {
+                          System.out.println("Lines containing tab characters detected in resource file:");
+                          containsTab = true;
+                        }
+                        System.out.println(line);
+                      }
+                    }
+                    fileReader.close();
+                    bufferReader.close();
+                    !containsTab
+                  ]]></condition>
+                </evaluateBeanshell>
+              </rules>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
See also https://github.com/eclipse/eclipse.jdt.core/pull/62, which is a subset of https://github.com/eclipse/eclipse.jdt.core/pull/63. See also the corresponding upstream [Eclipse Bugzilla issue # 573153](https://bugs.eclipse.org/bugs/show_bug.cgi?id=573153).

@aclement, you asked for smaller PRs, this is one. I hope that will make it easier for you to accept it in a timely fashion. 🙂