### PR TITLE
Exclude more stuff from build artifact (Apache Felix, Eclipse JFace)

### DIFF
--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -653,8 +653,14 @@
                 <filter>
                   <artifact>*</artifact>
                   <excludes>
-                    <exclude>*</exclude>
+                    <!-- These are from org.eclipse.jdt.core/build.xml -->
                     <exclude>META-INF/**</exclude>
+                    <exclude>org/apache/**</exclude>
+                    <exclude>org/w3c/**</exclude>
+                    <exclude>org/xml/**</exclude>
+                    <exclude>org/eclipse/jface/**</exclude>
+                    <!-- These seem to be unnecessary without OSGi, too -->
+                    <exclude>*</exclude>
                     <exclude>OSGI-INF/**</exclude>
                     <exclude>about_files/**</exclude>
                     <exclude>natives/**</exclude>


### PR DESCRIPTION
@aclement noticed that there was stuff inside aspectjtools.jar which in 1.9.6 was not there. I thought it was just new content from JDT dependencies, but actually Apache Felix and Eclipse JFace existed in the dependencies before, but were explicitly excluded in the old Ant build. I missed to port that one line to Maven - good catch, Andy!