### PR TITLE
Replace OSGi dependency ranges by fixed versions

### DIFF
--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -787,45 +787,151 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <!--
+      Taken from:
+      https://search.maven.org/artifact/org.eclipse.jdt/org.eclipse.jdt.core/3.25.0/jar
+      Then click "Browse" (top right of the page) and you see all artifacts, among them the original POM:
+      https://repo1.maven.org/maven2/org/eclipse/jdt/org.eclipse.jdt.core/3.25.0/org.eclipse.jdt.core-3.25.0.pom
+      Module 'org.eclipse.jdt.compiler.apt' only depends on 'org.eclipse.jdt.core' (this module), as you can see here:
+      https://search.maven.org/artifact/org.eclipse.jdt/org.eclipse.jdt.compiler.apt/1.3.1200/jar
+
+      Result of 'mvn dependency:tree' on POM with version ranges taken from the above (optional dependencies omitted),
+      executed 2021-05-08T12:50:02+07:00
+
+      org.aspectj:org.eclipse.jdt.core:jar:3.25.0-SNAPSHOT
+      +- org.eclipse.platform:org.eclipse.core.resources:jar:3.14.0:compile
+      |  \- org.eclipse.platform:org.eclipse.core.expressions:jar:3.7.100:compile (version selected from constraint [3.2.0,4.0.0))
+      +- org.eclipse.platform:org.eclipse.core.runtime:jar:3.20.100:compile
+      |  +- org.eclipse.platform:org.eclipse.osgi:jar:3.16.200:compile (version selected from constraint [3.13.0,4.0.0))
+      |  +- org.eclipse.platform:org.eclipse.equinox.common:jar:3.14.100:compile (version selected from constraint [3.14.0,4.0.0))
+      |  +- org.eclipse.platform:org.eclipse.core.jobs:jar:3.10.1100:compile (version selected from constraint [3.10.0,4.0.0))
+      |  +- org.eclipse.platform:org.eclipse.equinox.registry:jar:3.10.100:compile (version selected from constraint [3.10.0,4.0.0))
+      |  +- org.eclipse.platform:org.eclipse.equinox.preferences:jar:3.8.200:compile (version selected from constraint [3.7.0,4.0.0))
+      |  +- org.eclipse.platform:org.eclipse.core.contenttype:jar:3.7.900:compile (version selected from constraint [3.7.0,4.0.0))
+      |  \- org.eclipse.platform:org.eclipse.equinox.app:jar:1.5.100:compile (version selected from constraint [1.3.0,))
+      +- org.eclipse.platform:org.eclipse.core.filesystem:jar:1.7.700:compile
+      +- org.eclipse.platform:org.eclipse.text:jar:3.11.0:compile
+      |  \- org.eclipse.platform:org.eclipse.core.commands:jar:3.9.800:compile (version selected from constraint [3.5.0,4.0.0))
+      +- java:javax15api:jar:1.0:system
+      \- org.aspectj:aspectjrt:jar:1.9.6:compile
+      
+      Repeat the same procedure again whenever you upgrade JDT Core via merge from upstream. Then update direct and
+      transitive dependencies (maybe there are new or absolete ones) and fix their versions in this dependency
+      management section. Otherwise, AspectJ JDT Core builds would not be repeatable, pulling updated dependency class
+      files into the uber JAR whenever a dependency version is upgraded within its version number range.
+      
+      After dependency-managing all ranges to fixed version in the tree above, running 'mvn dependency:tree' again
+      should yield a clean dependency tree without any "version selected from constraint" sections.
+    -->
+    <dependencies>
+      
+      <!-- Direct dependencies (use below in 'dependencies' section) -->
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.resources</artifactId>
+        <version>3.14.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.runtime</artifactId>
+        <version>3.20.100</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.filesystem</artifactId>
+        <version>1.7.700</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.text</artifactId>
+        <version>3.11.0</version>
+      </dependency>
+      <!-- Not this one, because optional=true and not used in AspectJ -->
+      <!--
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.team.core</artifactId>
+        <version>[3.1.0,4.0.0)</version>
+        <optional>true</optional>
+      </dependency>
+      -->
+      
+      <!-- Transitive dependencies from dependency tree -->
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.expressions</artifactId>
+        <version>3.7.100</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.osgi</artifactId>
+        <version>3.16.200</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.common</artifactId>
+        <version>3.14.100</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.jobs</artifactId>
+        <version>3.10.1100</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.registry</artifactId>
+        <version>3.10.100</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.preferences</artifactId>
+        <version>3.8.200</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.contenttype</artifactId>
+        <version>3.7.900</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.app</artifactId>
+        <version>1.5.100</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.commands</artifactId>
+        <version>3.9.800</version>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!--
       Taken from:
       https://search.maven.org/artifact/org.eclipse.jdt/org.eclipse.jdt.core/3.25.0/jar
       Then click "Browse" (top right of the page) and you see all artifacts, among them the original POM:
       https://repo1.maven.org/maven2/org/eclipse/jdt/org.eclipse.jdt.core/3.25.0/org.eclipse.jdt.core-3.25.0.pom
-      Module 'org.eclipse.jdt.compiler.apt' only depends on this one, as you can see e.g. here:
+      Module 'org.eclipse.jdt.compiler.apt' only depends on 'org.eclipse.jdt.core' (this module), as you can see here:
       https://search.maven.org/artifact/org.eclipse.jdt/org.eclipse.jdt.compiler.apt/1.3.1200/jar
     -->
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.core.resources</artifactId>
-      <version>[3.14.0,4.0.0)</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.core.runtime</artifactId>
-      <version>[3.13.0,4.0.0)</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.core.filesystem</artifactId>
-      <version>[1.7.0,2.0.0)</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.text</artifactId>
-      <version>[3.6.0,4.0.0)</version>
     </dependency>
-    <!-- Not this one, because optional=true -->
-    <!--
-    <dependency>
-      <groupId>org.eclipse.platform</groupId>
-      <artifactId>org.eclipse.team.core</artifactId>
-      <version>[3.1.0,4.0.0)</version>
-      <optional>true</optional>
-    </dependency>
-    -->
-
     <dependency>
       <groupId>java</groupId>
       <artifactId>javax15api</artifactId>


### PR DESCRIPTION
Until now, I had simply copied the dependencies section from the Maven Central version of JDT Core. Actually, this can lead to non-repeatable builds whenever an upstream dependency gets updated within the version range. I therefore analysed the output of `mvn dependency:tree` and made sure to add fixed dependency versions for both direct and transitive
dependencies (minus optional ones) to a `dependencyManagement` section in the POM. This makes sure that we always compile against the same versions and include the same set of dependency class files into our uber JAR, which subsequently is used in AspectJ, i.e. changed class files would also bleed over into `aspectjtools.jar`.

The downside to this is that whenever we merge in upstream changesdepending on other versions, we have to determine and version-manage them again.

@aclement, maybe you want to merge #9 and #10 first, then I can rebase this one on the merged commit and you can cleanly fast-forward it.