### PR TITLE
Include JFace classes in order to fix javadoc generation in AspectJ

### DIFF
--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -708,8 +708,10 @@
                     <exclude>org/apache/**</exclude>
                     <exclude>org/w3c/**</exclude>
                     <exclude>org/xml/**</exclude>
-                    <exclude>org/eclipse/jface/**</exclude>
-                    <!-- These seem to be unnecessary without OSGi, too -->
+                    <!-- Excluding JFace breaks javadoc generation in AspectJ due to missing classes -->
+                    <!--<exclude>org/eclipse/jface/**</exclude>-->
+
+                    <!-- These seem to be unnecessary for AspectJ, because it is ignorant of OSGi  -->
                     <exclude>*</exclude>
                     <exclude>OSGI-INF/**</exclude>
                     <exclude>about_files/**</exclude>


### PR DESCRIPTION
When e.g. generating javadocs for AspectJ Tools, the missing JFace classes make JDK 9+ javadoc generators exit without generating any documentation. In JDK 8, the generator would simply continue despite reporting errors, but this was changed for JDK 9, because it can lead to inconsistent results.

Honestly, the missing classes were half a bug anyway, because they are being referenced by other classes in the package. We are just lucky that AJC does not seem to ever call classes or trigger the classloader to load classes needing any JFace stuff.