### PR TITLE
Upgrade license from EPLv1 to EPLv2 in lock-step with AspectJ 1.9.7

### DIFF
--- a/.github/workflows/jdt-aspectj-deploy.yml
+++ b/.github/workflows/jdt-aspectj-deploy.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2021 Contributors.
+# All rights reserved.
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Public License v 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
 

--- a/org.eclipse.jdt.compiler.apt/src/org/eclipse/jdt/internal/compiler/apt/dispatch/AjBatchFilerImpl.java
+++ b/org.eclipse.jdt.compiler.apt/src/org/eclipse/jdt/internal/compiler/apt/dispatch/AjBatchFilerImpl.java
@@ -1,9 +1,10 @@
 /*******************************************************************************
  * Copyright (c) 2000, 2014 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/CompilerAdapter.aj
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/CompilerAdapter.aj
@@ -2,9 +2,9 @@
  * Copyright (c) 2005 Contributors.
  * All rights reserved.
  * This program and the accompanying materials are made available
- * under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution and is available at
- * http://eclipse.org/legal/epl-v10.html
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *
  * Contributors:
  *   Adrian Colyer			Initial implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/DefaultCompilerAdapter.java
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/DefaultCompilerAdapter.java
@@ -1,10 +1,11 @@
 // AspectJ Extension
 /*******************************************************************************
  * Copyright (c) 2004 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials 
- * are made available under the terms of the Common Public License v1.0
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  * 
  * Contributors:
  *     IBM Corporation - initial API and implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/ICompilerAdapter.java
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/ICompilerAdapter.java
@@ -1,10 +1,11 @@
 // AspectJ Extension
 /*******************************************************************************
  * Copyright (c) 2004 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials 
- * are made available under the terms of the Common Public License v1.0
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  * 
  * Contributors:
  *     IBM Corporation - initial API and implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/ICompilerAdapterFactory.java
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/ICompilerAdapterFactory.java
@@ -1,10 +1,11 @@
 // AspectJ Extension
 /*******************************************************************************
  * Copyright (c) 2004 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials 
- * are made available under the terms of the Common Public License v1.0
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  * 
  * Contributors:
  *     IBM Corporation - initial API and implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/AnonymousClassCreationListener.java
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/AnonymousClassCreationListener.java
@@ -1,10 +1,10 @@
 /* *******************************************************************
  * Copyright (c) 2005 Contributors.
- * All rights reserved. 
- * This program and the accompanying materials are made available 
- * under the terms of the Eclipse Public License v1.0 
- * which accompanies this distribution and is available at 
- * http://eclipse.org/legal/epl-v10.html 
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *  
  * Contributors: 
  *   Adrian Colyer			Initial implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/AnonymousClassPublisher.aj
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/AnonymousClassPublisher.aj
@@ -1,10 +1,10 @@
 /* *******************************************************************
  * Copyright (c) 2005 Contributors.
- * All rights reserved. 
- * This program and the accompanying materials are made available 
- * under the terms of the Eclipse Public License v1.0 
- * which accompanies this distribution and is available at 
- * http://eclipse.org/legal/epl-v10.html 
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *  
  * Contributors: 
  *   Adrian Colyer			Initial implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/OwningClassSupportForFieldBindings.aj
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/OwningClassSupportForFieldBindings.aj
@@ -1,10 +1,10 @@
 /* *******************************************************************
  * Copyright (c) 2005 Contributors.
- * All rights reserved. 
- * This program and the accompanying materials are made available 
- * under the terms of the Eclipse Public License v1.0 
- * which accompanies this distribution and is available at 
- * http://eclipse.org/legal/epl-v10.html 
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *  
  * Contributors: 
  *   Adrian Colyer			Initial implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/OwningClassSupportForMethodBindings.aj
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/OwningClassSupportForMethodBindings.aj
@@ -1,10 +1,10 @@
 /* *******************************************************************
  * Copyright (c) 2005 Contributors.
- * All rights reserved. 
- * This program and the accompanying materials are made available 
- * under the terms of the Eclipse Public License v1.0 
- * which accompanies this distribution and is available at 
- * http://eclipse.org/legal/epl-v10.html 
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *  
  * Contributors: 
  *   Adrian Colyer			Initial implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/WarnOnSwallowedException.aj
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/lookup/WarnOnSwallowedException.aj
@@ -1,10 +1,10 @@
 /********************************************************************
  * Copyright (c) 2006 Contributors.
- * All rights reserved. 
- * This program and the accompanying materials are made available 
- * under the terms of the Eclipse Public License v1.0 
- * which accompanies this distribution and is available at 
- * http://eclipse.org/legal/epl-v10.html 
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *  
  * Contributors: 
  *   Adrian Colyer			Initial implementation

--- a/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/parser/AllowAssertAndEnumAsIdentifierTokensInPointcutExpressions.aj
+++ b/org.eclipse.jdt.core/aspectj/org/aspectj/ajdt/internal/compiler/parser/AllowAssertAndEnumAsIdentifierTokensInPointcutExpressions.aj
@@ -1,10 +1,10 @@
 /* *******************************************************************
  * Copyright (c) 2005 Contributors.
- * All rights reserved. 
- * This program and the accompanying materials are made available 
- * under the terms of the Eclipse Public License v1.0 
- * which accompanies this distribution and is available at 
- * http://eclipse.org/legal/epl-v10.html 
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *  
  * Contributors: 
  *   Adrian Colyer			Initial implementation

--- a/org.eclipse.jdt.core/build.xml
+++ b/org.eclipse.jdt.core/build.xml
@@ -1,3 +1,11 @@
+<!--
+ Copyright (c) 2014 Contributors. 
+ All rights reserved.
+ This program and the accompanying materials are made available
+ under the terms of the Eclipse Public License v 2.0
+ which accompanies this distribution, and is available at
+ https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+-->
 <project name="ShadowJdtCore" basedir="." default="make.jdtcore.jar">
 
   <property name="eclipse.home" value="c:/Program Files/Eclipse/2019-12"/>

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/IAttribute.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/IAttribute.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 2002 Palo Alto Research Center, Incorporated (PARC) 
- * and others.  All rights reserved. 
- * This program and the accompanying materials are made available under
- * the terms of the Common Public License v1.0 which accompanies this
- * distribution, available at http://www.eclipse.org/legal/cpl-v1.0.html
+ * and others.
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  * 
  * Contributors:
  *     PARC       - initial API and implementation

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/IMemberFinder.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/IMemberFinder.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 2002 Palo Alto Research Center, Incorporated (PARC) 
- * and others.  All rights reserved. 
- * This program and the accompanying materials are made available under
- * the terms of the Common Public License v1.0 which accompanies this
- * distribution, available at http://www.eclipse.org/legal/cpl-v1.0.html
+ * and others.
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  * 
  * Contributors:
  *     PARC       - initial API and implementation

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/IPrivilegedHandler.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/IPrivilegedHandler.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 2002 Palo Alto Research Center, Incorporated (PARC) 
- * and others.  All rights reserved. 
- * This program and the accompanying materials are made available under
- * the terms of the Common Public License v1.0 which accompanies this
- * distribution, available at http://www.eclipse.org/legal/cpl-v1.0.html
+ * and others.
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  * 
  * Contributors:
  *     PARC       - initial API and implementation

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/ITypeFinder.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/ITypeFinder.java
@@ -1,9 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010 Contributors
- * and others.  All rights reserved. 
- * This program and the accompanying materials are made available under
- * the terms of the Common Public License v1.0 which accompanies this
- * distribution, available at http://www.eclipse.org/legal/cpl-v1.0.html
+ * Copyright (c) 2010 Contributors and others.
+ * All rights reserved.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  * 
  * Contributors:
  *     Andy Clement

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -3,9 +3,9 @@
  *               2013, contributors
  * All rights reserved.
  * This program and the accompanying materials are made available
- * under the terms of the Common Public License v1.0
- * which accompanies this distribution and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *
  * Contributors:
  *     PARC     initial implementation

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -3,9 +3,9 @@
  *               2003,2004 contributors
  * All rights reserved.
  * This program and the accompanying materials are made available
- * under the terms of the Common Public License v1.0
- * which accompanies this distribution and is available at
- * http://www.eclipse.org/legal/cpl-v10.html
+ * under the terms of the Eclipse Public License v 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
  *
  * Contributors:
  *     PARC     initial implementation

--- a/org.eclipse.jdt.core/list-jdtDepends.sh
+++ b/org.eclipse.jdt.core/list-jdtDepends.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/bash
 
+# Copyright (c) 2021 Contributors.
+# All rights reserved.
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Public License v 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt
+
 # List all 'jdtDepends' JARs used by build.xml.
 #
 # Caveat: There might be multiple versions per JAR.
@@ -9,7 +16,7 @@
 # ./list-jdtDepends.sh /c/Program\ Files/Eclipse/2019-12
 #
 # Then open the file and copy the '<zipfileset .../>' lines to build.xml
-
+#
 # Can be something like "/c/Program\ Files/Eclipse/2019-12" or,
 # if using Eclipse Installer (by Oomph), something like "/c/Users/me/.p2/pool"
 export eclipseHome="$1"

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -240,16 +240,9 @@
   <url>https://www.eclipse.org/aspectj/</url>
 
   <licenses>
-    <!-- Eclipse JDT original licence -->
     <license>
       <name>Eclipse Public License - v 2.0</name>
-      <url>https://www.eclipse.org/legal/epl-v20.html</url>
-      <distribution>repo</distribution>
-    </license>
-    <!-- AspectJ licence -->
-    <license>
-      <name>Eclipse Public License - v 1.0</name>
-      <url>https://www.eclipse.org/legal/epl-v10.html</url>
+      <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
Double licensing is no longer required, because for release 1.9.7 AspectJ upgrades to EPLv2, which already corresponds to JDT Core.