### PR TITLE
Fix AspectJ GitHub issue #105 in release 1.9.8.RC3

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -950,6 +950,9 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 				return annotations;
 			} else {
 				annotation.recipient = recipient;
+				// AspectJ Extension: https://github.com/eclipse/org.aspectj/issues/105
+				if (annotation.resolvedType == null)
+        // End AspectJ Extension
 				annotation.resolveType(scope);
 				// null if receiver is a package binding
 				if (annotations != null) {

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -302,7 +302,7 @@
 
   <groupId>org.aspectj</groupId>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>1.9.8-SNAPSHOT</version>
+  <version>1.9.8.RC3</version>
 
   <name>JDT Core for AspectJ</name>
   <description>

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -302,7 +302,7 @@
 
   <groupId>org.aspectj</groupId>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>1.9.8.RC3</version>
+  <version>1.9.8-SNAPSHOT</version>
 
   <name>JDT Core for AspectJ</name>
   <description>


### PR DESCRIPTION
See eclipse/org.aspectj#105. This was broken since AspectJ 1.9.5, probably due to an accidentally removed `if` condition in `o.e.jdt.internal.compiler.ast.ASTNode.resolveAnnotations`.