### PR TITLE
Improve handling of closed and re-opened JAR classpath files

### DIFF
--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJmod.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJmod.java
@@ -55,6 +55,14 @@ public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageN
 	if (!isPackage(qualifiedPackageName, moduleName))
 		return null; // most common case
 
+	// AspectJ Extension
+	try {
+		ensureOpen();
+	}
+	catch (IOException e) {
+		throw new RuntimeException(e);
+	}
+	// End AspectJ Extension
 	try {
 		qualifiedBinaryFileName = new String(CharOperation.append(CLASSES_FOLDER, qualifiedBinaryFileName.toCharArray()));
 		IBinaryType reader = ClassFileReader.read(this.zipFile, qualifiedBinaryFileName);
@@ -97,6 +105,14 @@ public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageN
 @Override
 public boolean hasAnnotationFileFor(String qualifiedTypeName) {
 	qualifiedTypeName = new String(CharOperation.append(CLASSES_FOLDER, qualifiedTypeName.toCharArray()));
+	// AspectJ Extension
+	try {
+		ensureOpen();
+	}
+	catch (IOException e) {
+		throw new RuntimeException(e);
+	}
+	// End AspectJ Extension
 	return this.zipFile.getEntry(qualifiedTypeName+ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX) != null;
 }
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -106,6 +122,14 @@ public char[][][] findTypeNames(final String qualifiedPackageName, String module
 		return null; // most common case
 	final char[] packageArray = qualifiedPackageName.toCharArray();
 	final ArrayList answers = new ArrayList();
+	// AspectJ Extension
+	try {
+		ensureOpen();
+	}
+	catch (IOException e) {
+		throw new RuntimeException(e);
+	}
+	// End AspectJ Extension
 	nextEntry : for (Enumeration e = this.zipFile.entries(); e.hasMoreElements(); ) {
 		String fileName = ((ZipEntry) e.nextElement()).getName();
 
@@ -143,6 +167,14 @@ public synchronized char[][] getModulesDeclaringPackage(String qualifiedPackageN
 	this.packageCache = new HashSet<>(41);
 	this.packageCache.add(Util.EMPTY_STRING);
 
+	// AspectJ Extension
+	try {
+		ensureOpen();
+	}
+	catch (IOException e) {
+		throw new RuntimeException(e);
+	}
+	// End AspectJ Extension
 	for (Enumeration<? extends ZipEntry> e = this.zipFile.entries(); e.hasMoreElements(); ) {
 		char[] entryName = e.nextElement().getName().toCharArray();
 		int index = CharOperation.indexOf('/', entryName);
@@ -159,6 +191,14 @@ public synchronized char[][] getModulesDeclaringPackage(String qualifiedPackageN
 @Override
 public boolean hasCompilationUnit(String qualifiedPackageName, String moduleName) {
 	qualifiedPackageName += '/';
+	// AspectJ Extension
+	try {
+		ensureOpen();
+	}
+	catch (IOException e) {
+		throw new RuntimeException(e);
+	}
+	// End AspectJ Extension
 	for (Enumeration<? extends ZipEntry> e = this.zipFile.entries(); e.hasMoreElements(); ) {
 		char[] entryName = e.nextElement().getName().toCharArray();
 		int index = CharOperation.indexOf('/', entryName);

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathSourceJar.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathSourceJar.java
@@ -37,6 +37,14 @@ public class ClasspathSourceJar extends ClasspathJar {
 		if (!isPackage(qualifiedPackageName, moduleName))
 			return null; // most common case
 
+		// AspectJ Extension
+		try {
+			ensureOpen();
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+		// End AspectJ Extension
 		ZipEntry sourceEntry = this.zipFile.getEntry(qualifiedBinaryFileName.substring(0, qualifiedBinaryFileName.length() - 6)  + SUFFIX_STRING_java);
 		if (sourceEntry != null) {
 			try {

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -471,6 +471,16 @@ private NameEnvironmentAnswer findClass(String qualifiedTypeName, char[] typeNam
 			if (classpathEntry.hasAnnotationFileFor(qualifiedTypeName)) {
 				// in case of 'this.annotationsFromClasspath' we indeed search for .eea entries inside the main zipFile of the entry:
 				ZipFile zip = classpathEntry instanceof ClasspathJar ? ((ClasspathJar) classpathEntry).zipFile : null;
+				// AspectJ Extension
+				if (classpathEntry instanceof ClasspathJar) {
+					try {
+						((ClasspathJar) classpathEntry).ensureOpen();
+					}
+					catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				}
+				// End AspectJ Extension
 				boolean shouldClose = false; // don't close classpathEntry.zipFile, which we don't own
 				try {
 					if (zip == null) {

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -804,6 +804,7 @@
             would lead to double deployment and hence to an error "Transfer failed for ...-sources.jar 409 Conflict".
             See also https://issues.apache.org/jira/browse/MDEPLOY-254 and comments by Alexander Kriegisch.
           -->
+          <!-- TODO: Fixed in Maven 3.8.2. Consider enforcing minimum Maven version and removing 'attach=false'. -->
           <attach>false</attach>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -354,7 +354,7 @@
 <!--    <maven.javadoc.skip>false</maven.javadoc.skip>-->
 
     <!-- Dependency versions -->
-    <aspectj.version>1.9.8.M1</aspectj.version>
+    <aspectj.version>1.9.8</aspectj.version>
   </properties>
 
   <distributionManagement>

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -302,7 +302,7 @@
 
   <groupId>org.aspectj</groupId>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>1.9.8-SNAPSHOT</version>
+  <version>1.9.9-SNAPSHOT</version>
 
   <name>JDT Core for AspectJ</name>
   <description>


### PR DESCRIPTION
`ClasspathJar.openArchives` needs more safeguards when accessing possibly closed zip files (actually classpath JARs), making sure the get re-opened by calling `ClasspathJar.ensureOpen()`.

Relates to https://github.com/eclipse/org.aspectj/issues/125.